### PR TITLE
Added Credit class to commerce vocab and context

### DIFF
--- a/contexts/payswarm-v1.jsonld
+++ b/contexts/payswarm-v1.jsonld
@@ -87,6 +87,7 @@
     "voided": {"@id": "com:voided", "@type": "xsd:dateTime"},
     "ApplyExclusively": "com:ApplyExclusively",
     "ApplyInclusively": "com:ApplyInclusively",
+    "Credit": "com:Credit",
     "FinancialAccount": "com:Account",
     "FlatAmount": "com:FlatAmount",
     "Deposit": "com:Deposit",

--- a/specs/source/vocabs/commerce.html
+++ b/specs/source/vocabs/commerce.html
@@ -143,6 +143,40 @@ The following example expresses an account belonging to a person named
       </section>
 
 
+      <section id="Credit" about="https://w3id.org/commerce#Credit"
+        typeof="Class">
+        <h3>Credit</h3>
+          <p>
+A credit is similar to a transfer, however it records a credit (or IOU) between a sourrce and a destination.
+          </p>
+          <dl>
+            <dt>Status</dt>
+            <dd property="vs:term_status">unstable</dd>
+            <dt>Parent Class</dt>
+            <dd>Thing</dd>
+            <dt>Properties</dt>
+            <dd>forTransaction, source, destination, amount,
+currency, comment</dd>
+          </dl>
+          <p>
+The example below shows a transaction processor transfering funds from a
+local financial account to an external financial account.
+          </p>
+          <pre class="example prettyprint language-jsonld">
+{
+   "@context": "https://w3id.org/payswarm/v1",
+   "type": "Credit",
+   "forTransaction": "http://redbankexample.com/transactions/20110104#7827982";
+   "source": "http://redbankexample.com/accounts/12345#account",
+   "destination": "http://greencardexample.com/accounts/54321#account",
+   "amount": "8.00",
+   "currency": "USD",
+   "comment": "Transfer of $8.00 on 2010-10-16 at 12:34pm - Paying Jane back for pizza last Monday"
+}
+          </pre>
+      </section>
+
+
       <section id="Deposit" about="https://w3id.org/commerce#Deposit"
         typeof="Class">
         <h3>Deposit</h3>


### PR DESCRIPTION
I have added a Credit class to the commerce vocab and description to distinguish between a Transfer and a Credit (IOU).

I have NOT yet changed the example to reflect the new class, but the changes are minimal.  I can do this either after this pull request is reviewed, or as a single change.

Also changed is the context to let Credit be mapped to com:Credit
