### PR TITLE
added alias for LinkedDataSignature2015

### DIFF
--- a/contexts/security-v1.jsonld
+++ b/contexts/security-v1.jsonld
@@ -9,6 +9,7 @@
 
     "EncryptedMessage": "sec:EncryptedMessage",
     "GraphSignature2012": "sec:GraphSignature2012",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
     "CryptographicKey": "sec:Key",
 
     "authenticationTag": "sec:authenticationTag",


### PR DESCRIPTION
similar as existing one for GraphSignature2012

used as alias in https://github.com/digitalbazaar/jsonld-signatures/blob/f82ab8f143930d7f7cc99d93c1f955f8b5578d93/lib/jsonld-signatures.js#L206

discovered via https://github.com/digitalbazaar/jsonld-signatures/issues/4