### PR TITLE
Revert digestAlgorithm and digestValue overrides.

### DIFF
--- a/contexts/security-v2.jsonld
+++ b/contexts/security-v2.jsonld
@@ -7,10 +7,7 @@
     "EquihashProof2018": "sec:EquihashProof2018",
     "RsaSignature2018": "sec:RsaSignature2018",
     "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
-    "sha256": "http://www.w3.org/2001/04/xmlenc#sha256",
 
-    "digestAlgorithm": {"@id": "sec:digestAlgorithm", "@type": "@vocab"},
-    "digestValue": {"@id": "sec:digestValue", "@type": "@vocab"},
     "equihashParameterK": {"@id": "sec:equihashParameterK", "@type": "xsd:integer"},
     "equihashParameterN": {"@id": "sec:equihashParameterN", "@type": "xsd:integer"},
     "jws": "sec:jws",


### PR DESCRIPTION
This reverts 46c2376b6d048c868289dbaf9c5cd21c80027e55 due to:
- Confusion due to the override from v1.
- digestValue shouldn't be using `@vocab`.
- Unclear if digestAlgorithm should be using `@vocab` and how to
  coordinate on a shared set of values to use.