### PR TITLE
Fix typos in spec examples for pub/privateKeyPem

### DIFF
--- a/specs/source/vocabs/security.html
+++ b/specs/source/vocabs/security.html
@@ -406,8 +406,8 @@ is described in the <a href="https://w3id.org/commerce">Commerce Vocabulary</a>.
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "privateKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+  "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
 </pre>
       </section>
@@ -699,7 +699,7 @@ that expires on January 3rd 2014:
   "created": "2012-01-03T14:34:57+0000",
   "expires": "2014-01-03T14:34:57+0000",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n",
 }
         </pre>
       </section>
@@ -866,7 +866,7 @@ signed by a software agent of the owner:
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>
@@ -915,7 +915,7 @@ that has been abbreviated for the sake of the readability of the example.
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "privateKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
+  "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
 }
         </pre>
       </section>
@@ -943,7 +943,7 @@ to the identity <code>https://payswarm.example.com/i/bob</code>.
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>
@@ -1037,7 +1037,7 @@ revoked on May 5th 2012:
   "created": "2012-01-03T14:34:57+0000",
   "revoked": "2012-05-01T18:11:19+0000",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n",
 }
         </pre>
       </section>


### PR DESCRIPTION
The values for the `publicKeyPem` and `privateKeyPem` keys appear to be swapped in the spec examples.